### PR TITLE
Feature/gh 8 temperatures filter and sorting

### DIFF
--- a/Odin.Api.IntegrationTests/Tests/Temperatures/GetAllTemperaturesTests.cs
+++ b/Odin.Api.IntegrationTests/Tests/Temperatures/GetAllTemperaturesTests.cs
@@ -306,4 +306,66 @@ public class GetAllTemperaturesTests(ApiFactory factory) : IAsyncLifetime
 
         temperatures.Should().BeEmpty();
     }
+
+    [Fact]
+    public async Task GetTemperatures_WithSortAscending_ReturnsOkAndTemperaturesInTimestampAsc()
+    {
+        // Arrange
+        var device1 = new Device { Name = "Arduino Uno R3 TMP36 Button Serial" };
+        var device2 = new Device { Name = "Raspberry Pi Pico Internal Temperature Wifi" };
+        await factory.InsertAsync(device1, device2);
+
+        var degreesCelsiusUnit = new Unit { Name = "Degrees Celsius", Symbol = "°C" };
+        await factory.InsertAsync(degreesCelsiusUnit);
+
+        var temperature1 = new Temperature()
+        {
+            DeviceId = device1.Id,
+            Timestamp = DateTime.UtcNow.AddDays(-1),
+            Value = 24.5,
+            UnitId = degreesCelsiusUnit.Id
+        };
+        var temperature2 = new Temperature()
+        {
+            DeviceId = device2.Id,
+            Timestamp = DateTime.UtcNow,
+            Value = 26.9,
+            UnitId = degreesCelsiusUnit.Id
+        };
+        await factory.InsertAsync(temperature1, temperature2);
+
+        // Act
+        var response = await _httpClient.GetAsync("temperatures?sort=asc");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var responseJson = await response.Content.ReadFromJsonAsync<PaginatedResponseSchema<ApiTemperatureDto>>();
+        responseJson.Should().NotBeNull();
+
+        var meta = responseJson!.Meta;
+        var temperatures = responseJson!.Data;
+
+        meta.Page.Should().Be(1);
+        meta.Limit.Should().Be(PaginationConstants.DefaultPaginationLimit);
+        meta.Count.Should().Be(2);
+        meta.Total.Should().Be(2);
+
+        temperatures.Should().HaveCount(2).And.SatisfyRespectively(
+            earliestDto =>
+            {
+                earliestDto.Id.Should().Be(temperature1.Id);
+                earliestDto.DeviceId.Should().Be(device1.Id);
+                earliestDto.Timestamp.Should().Be(temperature1.Timestamp);
+                earliestDto.DegreesCelsius.Should().Be(temperature1.Value);
+            },
+            latestDto =>
+            {
+                latestDto.Id.Should().Be(temperature2.Id);
+                latestDto.DeviceId.Should().Be(device2.Id);
+                latestDto.Timestamp.Should().Be(temperature2.Timestamp);
+                latestDto.DegreesCelsius.Should().Be(temperature2.Value);
+            }
+        );
+    }
 }

--- a/Odin.Api/Endpoints/TemperatureEndpoints.cs
+++ b/Odin.Api/Endpoints/TemperatureEndpoints.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
 using Odin.Api.Endpoints.Pagination;
 using Odin.Api.Models;
 using Odin.Api.Services;
@@ -40,11 +41,17 @@ public static class TemperatureEndpoints
     ///    The sort order of results using the timestamp of the temperature taken. Valid values are "asc" and "desc".
     ///    Defaults to "desc" if not specified or an invalid value is provided.
     /// </param>
+    /// <param name="deviceIds">
+    ///    The device IDs of the devices to retrieve temperatures for. If not specified/empty, temperatures for
+    ///    all devices will be retrieved. Note that the query key is actually `deviceId` mapped to
+    ///    the `deviceIds` function parameter for clarity.
+    /// </param>
     public static async Task<Ok<PaginatedResponseSchema<ApiTemperatureDto>>> GetAllTemperatures(
         HttpContext httpContext,
         ITemperatureService temperatureService,
         double? minValue,
         double? maxValue,
+        [FromQuery(Name = "deviceId")] int[] deviceIds,
         bool withDevice = false,
         int page = 1,
         int limit = PaginationConstants.DefaultPaginationLimit,
@@ -63,6 +70,13 @@ public static class TemperatureEndpoints
             _ => TimestampSortOptions.Descending
         };
 
+        // var deviceIdsOption = deviceId.Length > 0 ? deviceId : null
+
+        // if (deviceId.Length > 0)
+        // {
+        //     deviceId = deviceId.Distinct().ToArray();
+        // }
+
         var options = new GetTemperatureOptions
         {
             WithDevice = withDevice,
@@ -71,6 +85,7 @@ public static class TemperatureEndpoints
             TimestampSort = timestampSort,
             MinValue = minValue,
             MaxValue = maxValue,
+            DeviceIds = deviceIds.Length > 0 ? deviceIds : null
         };
 
         var temperatures = page >= 1 ? await temperatureService.GetTemperaturesAsync(options) : [];

--- a/Odin.Api/Endpoints/TemperatureEndpoints.cs
+++ b/Odin.Api/Endpoints/TemperatureEndpoints.cs
@@ -70,13 +70,6 @@ public static class TemperatureEndpoints
             _ => TimestampSortOptions.Descending
         };
 
-        // var deviceIdsOption = deviceId.Length > 0 ? deviceId : null
-
-        // if (deviceId.Length > 0)
-        // {
-        //     deviceId = deviceId.Distinct().ToArray();
-        // }
-
         var options = new GetTemperatureOptions
         {
             WithDevice = withDevice,

--- a/Odin.Api/Endpoints/TemperatureEndpoints.cs
+++ b/Odin.Api/Endpoints/TemperatureEndpoints.cs
@@ -22,6 +22,14 @@ public static class TemperatureEndpoints
     /// <param name="withDevice">
     ///     If true, the device associated with the temperature will be included with each temperature in the response.
     /// </param>
+    /// <param name="minValue">
+    ///    The inclusive minimum value of the temperature to retrieve in degrees Celsius.
+    ///    If not specified, no minimum value filter will be applied.
+    /// </param>
+    /// <param name="maxValue">
+    ///   The inclusive maximum value of the temperature to retrieve in degrees Celsius.
+    ///   If not specified, no maximum value filter will be applied.
+    ///   </param>
     /// <param name="page">
     ///     The current page to retrieve from for the collection request.
     /// </param>
@@ -35,6 +43,8 @@ public static class TemperatureEndpoints
     public static async Task<Ok<PaginatedResponseSchema<ApiTemperatureDto>>> GetAllTemperatures(
         HttpContext httpContext,
         ITemperatureService temperatureService,
+        double? minValue,
+        double? maxValue,
         bool withDevice = false,
         int page = 1,
         int limit = PaginationConstants.DefaultPaginationLimit,
@@ -58,11 +68,13 @@ public static class TemperatureEndpoints
             WithDevice = withDevice,
             Page = page,
             Limit = limit,
-            TimestampSort = timestampSort
+            TimestampSort = timestampSort,
+            MinValue = minValue,
+            MaxValue = maxValue,
         };
 
         var temperatures = page >= 1 ? await temperatureService.GetTemperaturesAsync(options) : [];
-        var totalTemperatures = await temperatureService.CountTotalTemperaturesAsync();
+        var totalTemperatures = page >= 1 ? await temperatureService.CountTotalTemperaturesAsync(options) : 0;
 
         var temperatureDtos = temperatures.Select(t => t.ToDto(t.Device?.ToDto()));
 

--- a/Odin.Api/Services/TemperatureService/GetTemperaturesOptions.cs
+++ b/Odin.Api/Services/TemperatureService/GetTemperaturesOptions.cs
@@ -15,4 +15,6 @@ public class GetTemperatureOptions
     public double? MinValue { get; set; }
 
     public double? MaxValue { get; set; }
+
+    public int[]? DeviceIds { get; set; }
 }

--- a/Odin.Api/Services/TemperatureService/GetTemperaturesOptions.cs
+++ b/Odin.Api/Services/TemperatureService/GetTemperaturesOptions.cs
@@ -1,0 +1,14 @@
+using Odin.Api.Endpoints.Pagination;
+
+namespace Odin.Api.Services;
+
+public class GetTemperatureOptions
+{
+    public bool WithDevice { get; set; } = false;
+
+    public int Page { get; set; } = 1;
+
+    public int Limit { get; set; } = PaginationConstants.DefaultPaginationLimit;
+
+    public TimestampSortOptions TimestampSort { get; set; } = TimestampSortOptions.Descending;
+}

--- a/Odin.Api/Services/TemperatureService/GetTemperaturesOptions.cs
+++ b/Odin.Api/Services/TemperatureService/GetTemperaturesOptions.cs
@@ -11,4 +11,8 @@ public class GetTemperatureOptions
     public int Limit { get; set; } = PaginationConstants.DefaultPaginationLimit;
 
     public TimestampSortOptions TimestampSort { get; set; } = TimestampSortOptions.Descending;
+
+    public double? MinValue { get; set; }
+
+    public double? MaxValue { get; set; }
 }

--- a/Odin.Api/Services/TemperatureService/ITemperatureService.cs
+++ b/Odin.Api/Services/TemperatureService/ITemperatureService.cs
@@ -1,4 +1,3 @@
-using Odin.Api.Endpoints.Pagination;
 using Odin.Api.Endpoints.ResponseSchemas;
 using Odin.Api.Models;
 
@@ -10,10 +9,7 @@ public interface ITemperatureService
 
     public Task<int> CountTotalTemperaturesForDeviceAsync(int deviceId);
 
-    public Task<IEnumerable<Temperature>> GetTemperaturesAsync(
-        bool withDevice = false,
-        int page = 1,
-        int limit = PaginationConstants.DefaultPaginationLimit);
+    public Task<IEnumerable<Temperature>> GetTemperaturesAsync(GetTemperatureOptions options);
 
     public Task<Temperature?> GetTemperatureByIdAsync(int id);
 

--- a/Odin.Api/Services/TemperatureService/ITemperatureService.cs
+++ b/Odin.Api/Services/TemperatureService/ITemperatureService.cs
@@ -7,7 +7,10 @@ public interface ITemperatureService
 {
     public Task<int> CountTotalTemperaturesAsync();
 
-    public Task<int> CountTotalTemperaturesForDeviceAsync(int deviceId);
+    /// <summary>
+    ///     Counts total number of temperatures matching the given options. Useful for providing pagination metadata.
+    /// </summary>
+    public Task<int> CountTotalTemperaturesAsync(GetTemperatureOptions options);
 
     public Task<IEnumerable<Temperature>> GetTemperaturesAsync(GetTemperatureOptions options);
 

--- a/Odin.Api/Services/TemperatureService/TemperatureService.cs
+++ b/Odin.Api/Services/TemperatureService/TemperatureService.cs
@@ -77,6 +77,7 @@ public class TemperatureService(AppDbContext dbContext) : ITemperatureService
     {
         var minValue = options.MinValue;
         var maxValue = options.MaxValue;
+        var deviceIds = options.DeviceIds;
 
         var query = dbContext.Temperatures.AsQueryable();
 
@@ -85,6 +86,9 @@ public class TemperatureService(AppDbContext dbContext) : ITemperatureService
 
         if (maxValue is not null)
             query = query.Where(t => t.Value <= maxValue);
+
+        if (deviceIds is not null)
+            query = query.Where(t => deviceIds.Contains(t.DeviceId));
 
         return query;
     }

--- a/Odin.Api/Services/TemperatureService/TimestampSortOptions.cs
+++ b/Odin.Api/Services/TemperatureService/TimestampSortOptions.cs
@@ -1,0 +1,7 @@
+namespace Odin.Api.Services;
+
+public enum TimestampSortOptions
+{
+    Ascending,
+    Descending
+}

--- a/WebApp/src/features/devices/api/getDevices.tsx
+++ b/WebApp/src/features/devices/api/getDevices.tsx
@@ -8,7 +8,7 @@ import { apiDeviceDtoSchema } from './types';
 const getDevicesResponseSchema = z.array(apiDeviceDtoSchema);
 type GetDevicesResponse = z.infer<typeof getDevicesResponseSchema>;
 
-async function getDevices(): Promise<GetDevicesResponse> {
+export async function getDevices(): Promise<GetDevicesResponse> {
     const response = await axiosInstance.get('/devices');
     return getDevicesResponseSchema.parse(response.data);
 }

--- a/WebApp/src/features/devices/api/index.ts
+++ b/WebApp/src/features/devices/api/index.ts
@@ -3,3 +3,4 @@ export * from './deleteDevice';
 export * from './editDevice';
 export * from './getDevices';
 export * from './getDeviceDetails';
+export * from './types';

--- a/WebApp/src/features/temperatures/api/getManageTemperaturesPageData.tsx
+++ b/WebApp/src/features/temperatures/api/getManageTemperaturesPageData.tsx
@@ -1,0 +1,87 @@
+import { LoaderReturnType } from 'types';
+import { GetTemperatureOptions, getTemperaturesWithDevice } from './getTemperatures';
+import { getDevices } from 'features/devices';
+import { LoaderFunctionArgs, useLoaderData } from 'react-router-dom';
+import {
+    DEFAULT_PAGE,
+    DEFAULT_PAGE_LIMIT,
+    SearchFilterQueries,
+    getSearchFilterQueries,
+    useGetSearchFilterQueries,
+} from '../util';
+import { QueryClient, useQuery } from '@tanstack/react-query';
+
+interface GetManageTemperaturePageDataOptions {
+    getTemperaturesOptions: GetTemperatureOptions;
+}
+
+async function getManageTemperaturesPageData(options: GetManageTemperaturePageDataOptions) {
+    const [devices, temperatures] = await Promise.all([
+        getDevices(),
+        getTemperaturesWithDevice(options.getTemperaturesOptions),
+    ]);
+
+    return { devices, temperatures };
+}
+
+type GetManageTemperaturesPageLoaderReturnType = LoaderReturnType<
+    typeof getManageTemperaturesPageDataLoader
+>;
+
+const getPageQuery = (options: GetManageTemperaturePageDataOptions) => {
+    const {
+        page = DEFAULT_PAGE,
+        limit = DEFAULT_PAGE_LIMIT,
+        timestampSort = 'desc',
+        minValue,
+        maxValue,
+        deviceIds,
+    } = options.getTemperaturesOptions;
+
+    return {
+        queryKey: [
+            'temperatures',
+            { withDevice: true, page, limit, sort: timestampSort, minValue, maxValue, deviceIds },
+        ],
+        queryFn: () => getManageTemperaturesPageData(options),
+    };
+};
+
+export function getManageTemperaturesPageDataLoader(queryClient: QueryClient) {
+    return async ({ request }: LoaderFunctionArgs) => {
+        const urlSearchParams = new URL(request.url).searchParams;
+        const searchFilters = getSearchFilterQueries(urlSearchParams);
+        const query = getPageQuery({
+            getTemperaturesOptions: transformSearchFiltersToRequestOptions(searchFilters),
+        });
+        return queryClient.ensureQueryData(query);
+    };
+}
+
+export function useGetManageTemperaturesPageDataQuery() {
+    const searchFilters = useGetSearchFilterQueries();
+    const initialData = useLoaderData() as GetManageTemperaturesPageLoaderReturnType;
+
+    return useQuery({
+        ...getPageQuery({
+            getTemperaturesOptions: transformSearchFiltersToRequestOptions(searchFilters),
+        }),
+        initialData,
+    });
+}
+
+/**
+ * Helper function to transform the client side query parameters to the equivalent query parameters
+ * that the API expects in the request URL.
+ */
+function transformSearchFiltersToRequestOptions(
+    searchFilters: SearchFilterQueries
+): GetTemperatureOptions {
+    const { minTemperature, maxTemperature, ...filters } = searchFilters;
+
+    return {
+        ...filters,
+        minValue: minTemperature ?? undefined,
+        maxValue: maxTemperature ?? undefined,
+    };
+}

--- a/WebApp/src/features/temperatures/api/getTemperatures.tsx
+++ b/WebApp/src/features/temperatures/api/getTemperatures.tsx
@@ -1,19 +1,13 @@
 import axiosInstance from 'lib/axios';
-import { LoaderReturnType } from 'types';
-import { GetTemperaturesResponse, getTemperaturesResponseSchema } from './types';
-import { LoaderFunctionArgs, useLoaderData } from 'react-router-dom';
-import { QueryClient, useQuery } from '@tanstack/react-query';
 import {
     DEFAULT_PAGE,
     DEFAULT_PAGE_LIMIT,
     GetTemperaturesSearchKeys,
-    SearchFilterQueries,
     TimestampSort,
-    getSearchFilterQueries,
-    useGetSearchFilterQueries,
 } from '../util';
+import { GetTemperaturesResponse, getTemperaturesResponseSchema } from './types';
 
-interface GetTemperatureOptions {
+export interface GetTemperatureOptions {
     page?: number;
 
     /**
@@ -35,14 +29,20 @@ interface GetTemperatureOptions {
      * Maximum temperature (inclusive) value to filter by.
      */
     maxValue?: number;
+
+    /**
+     * Device ids to filter temperatures that are only measured by these specified devices.
+     */
+    deviceIds: string[];
 }
 
-async function getTemperaturesWithDevice({
+export async function getTemperaturesWithDevice({
     page = DEFAULT_PAGE,
     limit = DEFAULT_PAGE_LIMIT,
     timestampSort = 'desc',
     minValue,
     maxValue,
+    deviceIds,
 }: GetTemperatureOptions): Promise<GetTemperaturesResponse> {
     const urlSearchParams = new URLSearchParams();
 
@@ -50,6 +50,10 @@ async function getTemperaturesWithDevice({
     urlSearchParams.set(GetTemperaturesSearchKeys.PAGE, page.toString());
     urlSearchParams.set(GetTemperaturesSearchKeys.LIMIT, limit.toString());
     urlSearchParams.set(GetTemperaturesSearchKeys.TIMESTAMP_SORT, timestampSort);
+
+    deviceIds.forEach((deviceId) => {
+        urlSearchParams.append(GetTemperaturesSearchKeys.DEVICE_ID, deviceId);
+    });
 
     if (minValue != undefined) {
         urlSearchParams.set(GetTemperaturesSearchKeys.MIN_TEMPERATURE, minValue.toString());
@@ -62,64 +66,4 @@ async function getTemperaturesWithDevice({
     const endpoint = `/temperatures?${urlSearchParams.toString()}`;
     const response = await axiosInstance.get(endpoint);
     return getTemperaturesResponseSchema.parse(response.data);
-}
-
-const getTemperatureWithDeviceQuery = (options: GetTemperatureOptions) => {
-    const {
-        page = DEFAULT_PAGE,
-        limit = DEFAULT_PAGE_LIMIT,
-        timestampSort = 'desc',
-        minValue,
-        maxValue,
-    } = options;
-
-    return {
-        queryKey: [
-            'temperatures',
-            { withDevice: true, page, limit, sort: timestampSort, minValue, maxValue },
-        ],
-        queryFn: () => getTemperaturesWithDevice(options),
-    };
-};
-
-export function getTemperaturesWithDeviceLoader(queryClient: QueryClient) {
-    return async ({ request }: LoaderFunctionArgs) => {
-        const urlSearchParams = new URL(request.url).searchParams;
-        const searchFilters = getSearchFilterQueries(urlSearchParams);
-
-        const temperatureWithDeviceQuery = getTemperatureWithDeviceQuery(
-            transformSearchFiltersToRequestOptions(searchFilters)
-        );
-
-        return queryClient.ensureQueryData(temperatureWithDeviceQuery);
-    };
-}
-
-type GetTemperaturesLoaderReturnType = LoaderReturnType<typeof getTemperaturesWithDeviceLoader>;
-
-export function useGetTemperaturesWithDeviceQuery() {
-    const searchFilters = useGetSearchFilterQueries();
-    const initialData = useLoaderData() as GetTemperaturesLoaderReturnType;
-    return useQuery({
-        ...getTemperatureWithDeviceQuery(transformSearchFiltersToRequestOptions(searchFilters)),
-        initialData,
-    });
-}
-
-/**
- * Helper function to transform the client side query parameters to the equivalent query parameters
- * that the API expects in the request URL.
- */
-function transformSearchFiltersToRequestOptions(
-    searchFilters: SearchFilterQueries
-): GetTemperatureOptions {
-    const { page, limit, timestampSort, minTemperature, maxTemperature } = searchFilters;
-
-    return {
-        page,
-        limit,
-        timestampSort,
-        minValue: minTemperature ?? undefined,
-        maxValue: maxTemperature ?? undefined,
-    };
 }

--- a/WebApp/src/features/temperatures/api/getTemperatures.tsx
+++ b/WebApp/src/features/temperatures/api/getTemperatures.tsx
@@ -3,27 +3,51 @@ import { LoaderReturnType } from 'types';
 import { GetTemperaturesResponse, getTemperaturesResponseSchema } from './types';
 import { LoaderFunctionArgs, useLoaderData, useSearchParams } from 'react-router-dom';
 import { QueryClient, useQuery } from '@tanstack/react-query';
-import { DEFAULT_PAGE, DEFAULT_PAGE_LIMIT, getPageAndLimitFromUrlSearchParams } from '../util';
+import { DEFAULT_PAGE, DEFAULT_PAGE_LIMIT, TimestampSort, getSearchFilterQueries } from '../util';
 
-async function getTemperaturesWithDevice(
+interface GetTemperatureOptions {
+    page?: number;
+    limit?: number;
+
+    /**
+     * Sort order of temperature results by their recorded timestamps.
+     */
+    timestampSort?: TimestampSort;
+}
+
+async function getTemperaturesWithDevice({
     page = DEFAULT_PAGE,
-    limit = DEFAULT_PAGE_LIMIT
-): Promise<GetTemperaturesResponse> {
-    const endpoint = `/temperatures?withDevice=true&page=${page}&limit=${limit}`;
+    limit = DEFAULT_PAGE_LIMIT,
+    timestampSort = 'desc',
+}: GetTemperatureOptions): Promise<GetTemperaturesResponse> {
+    const urlSearchParams = new URLSearchParams();
+    urlSearchParams.set('withDevice', 'true');
+    urlSearchParams.set('page', page.toString());
+    urlSearchParams.set('limit', limit.toString());
+    urlSearchParams.set('sort', timestampSort);
+
+    const endpoint = `/temperatures?${urlSearchParams.toString()}`;
     const response = await axiosInstance.get(endpoint);
     return getTemperaturesResponseSchema.parse(response.data);
 }
 
-const getTemperatureWithDeviceQuery = (page = DEFAULT_PAGE, limit = DEFAULT_PAGE_LIMIT) => ({
-    queryKey: ['temperatures', { withDevice: true, page, limit }],
-    queryFn: () => getTemperaturesWithDevice(page, limit),
-});
+const getTemperatureWithDeviceQuery = (options: GetTemperatureOptions) => {
+    const { page = DEFAULT_PAGE, limit = DEFAULT_PAGE_LIMIT, timestampSort = 'desc' } = options;
+    return {
+        queryKey: ['temperatures', { withDevice: true, page, limit, sort: timestampSort }],
+        queryFn: () => getTemperaturesWithDevice(options),
+    };
+};
 
 export function getTemperaturesWithDeviceLoader(queryClient: QueryClient) {
     return async ({ request }: LoaderFunctionArgs) => {
         const urlSearchParams = new URL(request.url).searchParams;
-        const { page, limit } = getPageAndLimitFromUrlSearchParams(urlSearchParams);
-        const temperatureWithDeviceQuery = getTemperatureWithDeviceQuery(page, limit);
+        const { page, limit, timestampSort } = getSearchFilterQueries(urlSearchParams);
+        const temperatureWithDeviceQuery = getTemperatureWithDeviceQuery({
+            page,
+            limit,
+            timestampSort,
+        });
         return queryClient.ensureQueryData(temperatureWithDeviceQuery);
     };
 }
@@ -34,10 +58,10 @@ export function useGetTemperaturesWithDeviceQuery() {
     const [searchParams] = useSearchParams();
     const initialData = useLoaderData() as GetTemperaturesLoaderReturnType;
 
-    const { page, limit } = getPageAndLimitFromUrlSearchParams(searchParams);
+    const searchFilters = getSearchFilterQueries(searchParams);
 
     return useQuery({
-        ...getTemperatureWithDeviceQuery(page, limit),
+        ...getTemperatureWithDeviceQuery(searchFilters),
         initialData,
     });
 }

--- a/WebApp/src/features/temperatures/api/getTemperatures.tsx
+++ b/WebApp/src/features/temperatures/api/getTemperatures.tsx
@@ -1,30 +1,63 @@
 import axiosInstance from 'lib/axios';
 import { LoaderReturnType } from 'types';
 import { GetTemperaturesResponse, getTemperaturesResponseSchema } from './types';
-import { LoaderFunctionArgs, useLoaderData, useSearchParams } from 'react-router-dom';
+import { LoaderFunctionArgs, useLoaderData } from 'react-router-dom';
 import { QueryClient, useQuery } from '@tanstack/react-query';
-import { DEFAULT_PAGE, DEFAULT_PAGE_LIMIT, TimestampSort, getSearchFilterQueries } from '../util';
+import {
+    DEFAULT_PAGE,
+    DEFAULT_PAGE_LIMIT,
+    GetTemperaturesSearchKeys,
+    SearchFilterQueries,
+    TimestampSort,
+    getSearchFilterQueries,
+    useGetSearchFilterQueries,
+} from '../util';
 
 interface GetTemperatureOptions {
     page?: number;
+
+    /**
+     * Number of records to return per page.
+     */
     limit?: number;
 
     /**
      * Sort order of temperature results by their recorded timestamps.
      */
     timestampSort?: TimestampSort;
+
+    /**
+     * Minimum temperature (inclusive) value to filter by.
+     */
+    minValue?: number;
+
+    /**
+     * Maximum temperature (inclusive) value to filter by.
+     */
+    maxValue?: number;
 }
 
 async function getTemperaturesWithDevice({
     page = DEFAULT_PAGE,
     limit = DEFAULT_PAGE_LIMIT,
     timestampSort = 'desc',
+    minValue,
+    maxValue,
 }: GetTemperatureOptions): Promise<GetTemperaturesResponse> {
     const urlSearchParams = new URLSearchParams();
+
     urlSearchParams.set('withDevice', 'true');
-    urlSearchParams.set('page', page.toString());
-    urlSearchParams.set('limit', limit.toString());
-    urlSearchParams.set('sort', timestampSort);
+    urlSearchParams.set(GetTemperaturesSearchKeys.PAGE, page.toString());
+    urlSearchParams.set(GetTemperaturesSearchKeys.LIMIT, limit.toString());
+    urlSearchParams.set(GetTemperaturesSearchKeys.TIMESTAMP_SORT, timestampSort);
+
+    if (minValue != undefined) {
+        urlSearchParams.set(GetTemperaturesSearchKeys.MIN_TEMPERATURE, minValue.toString());
+    }
+
+    if (maxValue != undefined) {
+        urlSearchParams.set(GetTemperaturesSearchKeys.MAX_TEMPERATURE, maxValue.toString());
+    }
 
     const endpoint = `/temperatures?${urlSearchParams.toString()}`;
     const response = await axiosInstance.get(endpoint);
@@ -32,9 +65,19 @@ async function getTemperaturesWithDevice({
 }
 
 const getTemperatureWithDeviceQuery = (options: GetTemperatureOptions) => {
-    const { page = DEFAULT_PAGE, limit = DEFAULT_PAGE_LIMIT, timestampSort = 'desc' } = options;
+    const {
+        page = DEFAULT_PAGE,
+        limit = DEFAULT_PAGE_LIMIT,
+        timestampSort = 'desc',
+        minValue,
+        maxValue,
+    } = options;
+
     return {
-        queryKey: ['temperatures', { withDevice: true, page, limit, sort: timestampSort }],
+        queryKey: [
+            'temperatures',
+            { withDevice: true, page, limit, sort: timestampSort, minValue, maxValue },
+        ],
         queryFn: () => getTemperaturesWithDevice(options),
     };
 };
@@ -42,12 +85,12 @@ const getTemperatureWithDeviceQuery = (options: GetTemperatureOptions) => {
 export function getTemperaturesWithDeviceLoader(queryClient: QueryClient) {
     return async ({ request }: LoaderFunctionArgs) => {
         const urlSearchParams = new URL(request.url).searchParams;
-        const { page, limit, timestampSort } = getSearchFilterQueries(urlSearchParams);
-        const temperatureWithDeviceQuery = getTemperatureWithDeviceQuery({
-            page,
-            limit,
-            timestampSort,
-        });
+        const searchFilters = getSearchFilterQueries(urlSearchParams);
+
+        const temperatureWithDeviceQuery = getTemperatureWithDeviceQuery(
+            transformSearchFiltersToRequestOptions(searchFilters)
+        );
+
         return queryClient.ensureQueryData(temperatureWithDeviceQuery);
     };
 }
@@ -55,13 +98,28 @@ export function getTemperaturesWithDeviceLoader(queryClient: QueryClient) {
 type GetTemperaturesLoaderReturnType = LoaderReturnType<typeof getTemperaturesWithDeviceLoader>;
 
 export function useGetTemperaturesWithDeviceQuery() {
-    const [searchParams] = useSearchParams();
+    const searchFilters = useGetSearchFilterQueries();
     const initialData = useLoaderData() as GetTemperaturesLoaderReturnType;
-
-    const searchFilters = getSearchFilterQueries(searchParams);
-
     return useQuery({
-        ...getTemperatureWithDeviceQuery(searchFilters),
+        ...getTemperatureWithDeviceQuery(transformSearchFiltersToRequestOptions(searchFilters)),
         initialData,
     });
+}
+
+/**
+ * Helper function to transform the client side query parameters to the equivalent query parameters
+ * that the API expects in the request URL.
+ */
+function transformSearchFiltersToRequestOptions(
+    searchFilters: SearchFilterQueries
+): GetTemperatureOptions {
+    const { page, limit, timestampSort, minTemperature, maxTemperature } = searchFilters;
+
+    return {
+        page,
+        limit,
+        timestampSort,
+        minValue: minTemperature ?? undefined,
+        maxValue: maxTemperature ?? undefined,
+    };
 }

--- a/WebApp/src/features/temperatures/api/index.ts
+++ b/WebApp/src/features/temperatures/api/index.ts
@@ -1,2 +1,4 @@
+export * from './deleteTemperature';
+export * from './getManageTemperaturesPageData';
 export * from './getTemperatures';
 export * from './types';

--- a/WebApp/src/features/temperatures/components/DeviceSelect.tsx
+++ b/WebApp/src/features/temperatures/components/DeviceSelect.tsx
@@ -1,0 +1,49 @@
+import { Select, Option, Box, Chip, FormControl, FormLabel } from '@mui/joy';
+import { ApiDeviceDto } from 'features/devices';
+
+export type DeviceSelectOnChange = (
+    event:
+        | React.MouseEvent<Element, MouseEvent>
+        | React.KeyboardEvent<Element>
+        | React.FocusEvent<Element, Element>
+        | null,
+    newSelectedDeviceIds: string[]
+) => void;
+
+interface DeviceSelectProps {
+    devices: ApiDeviceDto[];
+    selectedDeviceIds: string[];
+    onChange?: DeviceSelectOnChange;
+}
+
+export default function DeviceSelect({ devices, selectedDeviceIds, onChange }: DeviceSelectProps) {
+    return (
+        <FormControl>
+            <FormLabel>My Devices</FormLabel>
+            <Select
+                value={selectedDeviceIds}
+                onChange={onChange}
+                placeholder="Select Devices"
+                multiple
+                slotProps={{
+                    listbox: { placement: 'bottom-start' },
+                }}
+                renderValue={(selected) => (
+                    <Box sx={{ display: 'flex', gap: '0.25rem' }}>
+                        {selected.map((selectedOption) => (
+                            <Chip variant="soft" color="primary" key={selectedOption.id}>
+                                {selectedOption.label}
+                            </Chip>
+                        ))}
+                    </Box>
+                )}
+            >
+                {devices.map((device) => (
+                    <Option key={device.id.toString()} value={device.id.toString()}>
+                        {device.name}
+                    </Option>
+                ))}
+            </Select>
+        </FormControl>
+    );
+}

--- a/WebApp/src/features/temperatures/components/ManageTemperaturesPage.tsx
+++ b/WebApp/src/features/temperatures/components/ManageTemperaturesPage.tsx
@@ -1,11 +1,13 @@
 import { Box, Button, Grid, Typography } from '@mui/joy';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
-import { useGetTemperaturesWithDeviceQuery } from '../api';
+import { useGetManageTemperaturesPageDataQuery } from '../api';
 import TemperaturesTable from './TemperaturesTable';
 import TemperatureFilterOptions from './TemperatureFilterOptions';
 
 export default function ManageTemperaturesPage() {
-    const { data: response } = useGetTemperaturesWithDeviceQuery();
+    const response = useGetManageTemperaturesPageDataQuery();
+
+    const { devices, temperatures } = response.data;
 
     return (
         <Box maxWidth="1920px" px="24px" mx="auto">
@@ -24,14 +26,14 @@ export default function ManageTemperaturesPage() {
             </Box>
             <Grid container my="36px" columnSpacing="36px">
                 <Grid xs={2}>
-                    <TemperatureFilterOptions />
+                    <TemperatureFilterOptions devices={devices} />
                 </Grid>
                 <Grid xs={10}>
                     <TemperaturesTable
-                        temperatures={response.data}
-                        totalRecords={response._meta.total}
-                        page={response._meta.page}
-                        rowsPerPage={response._meta.limit}
+                        temperatures={temperatures.data}
+                        totalRecords={temperatures._meta.total}
+                        page={temperatures._meta.page}
+                        rowsPerPage={temperatures._meta.limit}
                     />
                 </Grid>
             </Grid>

--- a/WebApp/src/features/temperatures/components/ManageTemperaturesPage.tsx
+++ b/WebApp/src/features/temperatures/components/ManageTemperaturesPage.tsx
@@ -1,13 +1,14 @@
-import { Box, Button, Typography } from '@mui/joy';
+import { Box, Button, Grid, Typography } from '@mui/joy';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
-import TemperaturesTable from './TemperaturesTable';
 import { useGetTemperaturesWithDeviceQuery } from '../api';
+import TemperaturesTable from './TemperaturesTable';
+import TemperatureFilterOptions from './TemperatureFilterOptions';
 
 export default function ManageTemperaturesPage() {
     const { data: response } = useGetTemperaturesWithDeviceQuery();
 
     return (
-        <Box maxWidth="1536px" px="24px" mx="auto">
+        <Box maxWidth="1920px" px="24px" mx="auto">
             <Box display="flex" justifyContent="space-between" alignItems="flex-start">
                 <Typography level="h2" component="h1">
                     Manage Temperatures
@@ -21,14 +22,19 @@ export default function ManageTemperaturesPage() {
                     Download (Coming Soon)
                 </Button>
             </Box>
-            <Box my="24px">
-                <TemperaturesTable
-                    temperatures={response.data}
-                    totalRecords={response._meta.total}
-                    page={response._meta.page}
-                    rowsPerPage={response._meta.limit}
-                />
-            </Box>
+            <Grid container my="36px" columnSpacing="36px">
+                <Grid xs={2}>
+                    <TemperatureFilterOptions />
+                </Grid>
+                <Grid xs={10}>
+                    <TemperaturesTable
+                        temperatures={response.data}
+                        totalRecords={response._meta.total}
+                        page={response._meta.page}
+                        rowsPerPage={response._meta.limit}
+                    />
+                </Grid>
+            </Grid>
         </Box>
     );
 }

--- a/WebApp/src/features/temperatures/components/TablePagination.tsx
+++ b/WebApp/src/features/temperatures/components/TablePagination.tsx
@@ -49,7 +49,7 @@ export default function TablePagination({
         onRowsPerPageChange?.(e, newValue);
     };
 
-    const start = (page - 1) * rowsPerPage + 1;
+    const start = totalRecords === 0 ? 0 : (page - 1) * rowsPerPage + 1;
     const end = Math.min(page * rowsPerPage, totalRecords);
     const isFirstPage = start === 1;
     const isLastPage = end === totalRecords;

--- a/WebApp/src/features/temperatures/components/TemperatureFilterOptions.tsx
+++ b/WebApp/src/features/temperatures/components/TemperatureFilterOptions.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import ClearIcon from '@mui/icons-material/Clear';
+import FilterAltIcon from '@mui/icons-material/FilterAlt';
+import { Box, Button, Stack } from '@mui/joy';
+import TemperatureRangeFilter from './TemperatureRangeFilter';
+import { useSearchParams } from 'react-router-dom';
+import {
+    DEFAULT_PAGE,
+    GetTemperaturesSearchKeys,
+    TemperatureRangeValues,
+    getSearchFilterQueries,
+} from '../util';
+
+const DEFAULT_TEMPERATURE_RANGE_VALUES: TemperatureRangeValues = [0, 50];
+const DEFAULT_TEMPERATURE_RANGE_MIN_VALUE = DEFAULT_TEMPERATURE_RANGE_VALUES[0];
+const DEFAULT_TEMPERATURE_RANGE_MAX_VALUE = DEFAULT_TEMPERATURE_RANGE_VALUES[1];
+
+export default function TemperatureFilterOptions() {
+    const [searchParams, setSearchParams] = useSearchParams();
+    const { minTemperature, maxTemperature } = getSearchFilterQueries(searchParams);
+
+    const [temperatureRangeValues, setTemperatureRangeValues] = useState<TemperatureRangeValues>([
+        minTemperature ?? DEFAULT_TEMPERATURE_RANGE_MIN_VALUE,
+        maxTemperature ?? DEFAULT_TEMPERATURE_RANGE_MAX_VALUE,
+    ]);
+
+    const handleTemperatureRangeFilterChange = (_: Event, newValues: TemperatureRangeValues) => {
+        setTemperatureRangeValues(newValues);
+    };
+
+    const handleClear = () => {
+        searchParams.set(GetTemperaturesSearchKeys.PAGE, DEFAULT_PAGE.toString());
+        searchParams.delete(GetTemperaturesSearchKeys.MIN_TEMPERATURE);
+        searchParams.delete(GetTemperaturesSearchKeys.MAX_TEMPERATURE);
+        setTemperatureRangeValues(DEFAULT_TEMPERATURE_RANGE_VALUES);
+        setSearchParams(searchParams, { replace: true });
+    };
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+
+        const [minValue, maxValue] = temperatureRangeValues;
+        searchParams.set(GetTemperaturesSearchKeys.PAGE, DEFAULT_PAGE.toString());
+        searchParams.set(GetTemperaturesSearchKeys.MIN_TEMPERATURE, minValue.toString());
+        searchParams.set(GetTemperaturesSearchKeys.MAX_TEMPERATURE, maxValue.toString());
+        setSearchParams(searchParams, { replace: true });
+    };
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <Stack spacing="32px">
+                <TemperatureRangeFilter
+                    values={temperatureRangeValues}
+                    maxValue={DEFAULT_TEMPERATURE_RANGE_MAX_VALUE}
+                    onChange={handleTemperatureRangeFilterChange}
+                />
+                <Box mt="24px" display="flex" alignItems="center" columnGap="12px">
+                    <Button
+                        variant="outlined"
+                        color="neutral"
+                        startDecorator={<ClearIcon />}
+                        sx={{ flex: 1 }}
+                        onClick={handleClear}
+                    >
+                        Clear
+                    </Button>
+                    <Button
+                        variant="solid"
+                        color="primary"
+                        startDecorator={<FilterAltIcon />}
+                        sx={{ flex: 1 }}
+                        type="submit"
+                    >
+                        Apply
+                    </Button>
+                </Box>
+            </Stack>
+        </form>
+    );
+}

--- a/WebApp/src/features/temperatures/components/TemperatureFilterOptions.tsx
+++ b/WebApp/src/features/temperatures/components/TemperatureFilterOptions.tsx
@@ -10,45 +10,86 @@ import {
     TemperatureRangeValues,
     getSearchFilterQueries,
 } from '../util';
+import { DeviceSelect } from '.';
+import { ApiDeviceDto } from 'features/devices';
+import { DeviceSelectOnChange } from './DeviceSelect';
 
 const DEFAULT_TEMPERATURE_RANGE_VALUES: TemperatureRangeValues = [0, 50];
 const DEFAULT_TEMPERATURE_RANGE_MIN_VALUE = DEFAULT_TEMPERATURE_RANGE_VALUES[0];
 const DEFAULT_TEMPERATURE_RANGE_MAX_VALUE = DEFAULT_TEMPERATURE_RANGE_VALUES[1];
 
-export default function TemperatureFilterOptions() {
+interface TemperatureFilterOptionsProps {
+    devices: ApiDeviceDto[];
+}
+
+/**
+ * Filters out device ids that do not exist in the list of devices. This makes sure only ids with
+ * a corresponding valid device can be selected.
+ */
+function initializeSelectedDeviceIds(deviceIds: string[], devices: ApiDeviceDto[]): string[] {
+    const deviceExistsWithId = (id: string) => devices.some((d) => d.id.toString() === id);
+    return deviceIds.filter(deviceExistsWithId);
+}
+
+export default function TemperatureFilterOptions({ devices }: TemperatureFilterOptionsProps) {
     const [searchParams, setSearchParams] = useSearchParams();
-    const { minTemperature, maxTemperature } = getSearchFilterQueries(searchParams);
+    const { minTemperature, maxTemperature, deviceIds } = getSearchFilterQueries(searchParams);
 
     const [temperatureRangeValues, setTemperatureRangeValues] = useState<TemperatureRangeValues>([
         minTemperature ?? DEFAULT_TEMPERATURE_RANGE_MIN_VALUE,
         maxTemperature ?? DEFAULT_TEMPERATURE_RANGE_MAX_VALUE,
     ]);
 
+    const [selectedDeviceIds, setSelectedDeviceIds] = useState<string[]>(() =>
+        initializeSelectedDeviceIds(deviceIds, devices)
+    );
+
     const handleTemperatureRangeFilterChange = (_: Event, newValues: TemperatureRangeValues) => {
         setTemperatureRangeValues(newValues);
+    };
+
+    const handleSelectedDevicesChange: DeviceSelectOnChange = (_, newValues) => {
+        setSelectedDeviceIds(newValues);
     };
 
     const handleClear = () => {
         searchParams.set(GetTemperaturesSearchKeys.PAGE, DEFAULT_PAGE.toString());
         searchParams.delete(GetTemperaturesSearchKeys.MIN_TEMPERATURE);
         searchParams.delete(GetTemperaturesSearchKeys.MAX_TEMPERATURE);
+        searchParams.delete(GetTemperaturesSearchKeys.DEVICE_ID);
+
         setTemperatureRangeValues(DEFAULT_TEMPERATURE_RANGE_VALUES);
+        setSelectedDeviceIds([]);
+
         setSearchParams(searchParams, { replace: true });
     };
 
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
 
+        // Selected devices
+        selectedDeviceIds.forEach((deviceId) => {
+            searchParams.append(GetTemperaturesSearchKeys.DEVICE_ID, deviceId);
+        });
+
+        // Temperature range values
         const [minValue, maxValue] = temperatureRangeValues;
         searchParams.set(GetTemperaturesSearchKeys.PAGE, DEFAULT_PAGE.toString());
         searchParams.set(GetTemperaturesSearchKeys.MIN_TEMPERATURE, minValue.toString());
         searchParams.set(GetTemperaturesSearchKeys.MAX_TEMPERATURE, maxValue.toString());
+
+        // Perform the search by replacing current search params with submitted ones
         setSearchParams(searchParams, { replace: true });
     };
 
     return (
         <form onSubmit={handleSubmit}>
             <Stack spacing="32px">
+                <DeviceSelect
+                    devices={devices}
+                    selectedDeviceIds={selectedDeviceIds}
+                    onChange={handleSelectedDevicesChange}
+                />
                 <TemperatureRangeFilter
                     values={temperatureRangeValues}
                     maxValue={DEFAULT_TEMPERATURE_RANGE_MAX_VALUE}
@@ -59,8 +100,8 @@ export default function TemperatureFilterOptions() {
                         variant="outlined"
                         color="neutral"
                         startDecorator={<ClearIcon />}
-                        sx={{ flex: 1 }}
                         onClick={handleClear}
+                        sx={{ flex: 1 }}
                     >
                         Clear
                     </Button>
@@ -68,8 +109,8 @@ export default function TemperatureFilterOptions() {
                         variant="solid"
                         color="primary"
                         startDecorator={<FilterAltIcon />}
-                        sx={{ flex: 1 }}
                         type="submit"
+                        sx={{ flex: 1 }}
                     >
                         Apply
                     </Button>

--- a/WebApp/src/features/temperatures/components/TemperatureRangeFilter.tsx
+++ b/WebApp/src/features/temperatures/components/TemperatureRangeFilter.tsx
@@ -1,0 +1,36 @@
+import { FormControl, FormHelperText, FormLabel, Slider } from '@mui/joy';
+import { TemperatureRangeValues } from '../util';
+
+interface TemperatureRangeFilterProps {
+    values: TemperatureRangeValues;
+    maxValue: number;
+    step?: number;
+    onChange?: (event: Event, newValues: TemperatureRangeValues, activeThumb: number) => void;
+}
+
+export default function TemperatureRangeFilter({
+    values,
+    onChange,
+    maxValue,
+    step,
+}: TemperatureRangeFilterProps) {
+    const formHelperText = `${values[0]} °C - ${values[1]} °C`;
+
+    return (
+        <FormControl sx={{ alignItems: 'center' }}>
+            <FormLabel sx={{ fontSize: '1rem' }}>Temperature Range</FormLabel>
+            <Slider
+                aria-label="Temperature Range"
+                sx={{ pt: '12px', pb: '4px' }}
+                value={values}
+                max={maxValue}
+                step={step}
+                size="sm"
+                onChange={(e, newValues, activeThumb) =>
+                    onChange?.(e, newValues as TemperatureRangeValues, activeThumb)
+                }
+            />
+            <FormHelperText>{formHelperText}</FormHelperText>
+        </FormControl>
+    );
+}

--- a/WebApp/src/features/temperatures/components/TemperatureRangeFilter.tsx
+++ b/WebApp/src/features/temperatures/components/TemperatureRangeFilter.tsx
@@ -18,7 +18,7 @@ export default function TemperatureRangeFilter({
 
     return (
         <FormControl sx={{ alignItems: 'center' }}>
-            <FormLabel sx={{ fontSize: '1rem' }}>Temperature Range</FormLabel>
+            <FormLabel>Temperature Range</FormLabel>
             <Slider
                 aria-label="Temperature Range"
                 sx={{ pt: '12px', pb: '4px' }}

--- a/WebApp/src/features/temperatures/components/TemperaturesTable.tsx
+++ b/WebApp/src/features/temperatures/components/TemperaturesTable.tsx
@@ -7,7 +7,7 @@ import DataCell from './DataCell';
 import TemperaturesTableRowMenu from './TemperaturesTableRowMenu';
 import TablePagination from './TablePagination';
 import { useSearchParams } from 'react-router-dom';
-import { DEFAULT_PAGE } from '../util';
+import { DEFAULT_PAGE, GetTemperaturesSearchKeys } from '../util';
 
 function formatTimestamp(timestamp: string) {
     return dayjs(timestamp).format('MMM DD, YYYY hh:mm:ss a');
@@ -25,7 +25,7 @@ interface TimestampHeaderCellProps {
 
 function TimestampHeaderCell({ onClick, arrowIconDirection }: TimestampHeaderCellProps) {
     return (
-        <th>
+        <th style={{ width: '300px' }}>
             <Link
                 underline="none"
                 color="primary"
@@ -63,20 +63,20 @@ export default function TemperaturesTable({
 
     const handleTimestampHeaderClick = () => {
         const newSortOrder = timestampSortOrder === 'asc' ? 'desc' : 'asc';
-        searchParams.set('sort', newSortOrder);
-        searchParams.set('page', DEFAULT_PAGE.toString());
+        searchParams.set(GetTemperaturesSearchKeys.TIMESTAMP_SORT, newSortOrder);
+        searchParams.set(GetTemperaturesSearchKeys.PAGE, DEFAULT_PAGE.toString());
         setSearchParams(searchParams, { replace: true });
     };
 
     const handleRowsPerPageChange = (_: React.SyntheticEvent | null, newValue: string) => {
-        searchParams.set('page', DEFAULT_PAGE.toString());
-        searchParams.set('limit', newValue);
+        searchParams.set(GetTemperaturesSearchKeys.PAGE, DEFAULT_PAGE.toString());
+        searchParams.set(GetTemperaturesSearchKeys.LIMIT, newValue);
         setSearchParams(searchParams, { replace: true });
     };
 
     const changePage = (newPage: number) => {
-        searchParams.set('page', newPage.toString());
-        searchParams.set('limit', rowsPerPage.toString());
+        searchParams.set(GetTemperaturesSearchKeys.PAGE, newPage.toString());
+        searchParams.set(GetTemperaturesSearchKeys.LIMIT, rowsPerPage.toString());
         setSearchParams(searchParams, { replace: true });
     };
 
@@ -102,7 +102,7 @@ export default function TemperaturesTable({
 
     return (
         <Sheet variant="outlined" sx={{ borderRadius: 'sm' }}>
-            <Table aria-label="Temperatures Table" noWrap hoverRow stickyHeader>
+            <Table aria-label="Temperatures Table" noWrap stickyHeader>
                 <thead>
                     <tr>
                         <TimestampHeaderCell

--- a/WebApp/src/features/temperatures/components/TemperaturesTable.tsx
+++ b/WebApp/src/features/temperatures/components/TemperaturesTable.tsx
@@ -1,14 +1,45 @@
-import { Box, Divider, Sheet, Table } from '@mui/joy';
+import { Box, Divider, Link, Sheet, Table } from '@mui/joy';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import { ApiTemperatureWithDeviceDto } from '../api';
 import dayjs from 'dayjs';
 import DataCell from './DataCell';
 import TemperaturesTableRowMenu from './TemperaturesTableRowMenu';
 import TablePagination from './TablePagination';
 import { useSearchParams } from 'react-router-dom';
-import { DEFAULT_PAGE } from '..';
+import { DEFAULT_PAGE } from '../util';
 
 function formatTimestamp(timestamp: string) {
     return dayjs(timestamp).format('MMM DD, YYYY hh:mm:ss a');
+}
+
+interface TimestampHeaderCellProps {
+    onClick?: (e: React.MouseEvent) => void;
+
+    /**
+     * Direction for the arrow icon to indicate the order of the results,
+     * intention is up is ascending, down is descending.
+     */
+    arrowIconDirection?: 'up' | 'down';
+}
+
+function TimestampHeaderCell({ onClick, arrowIconDirection }: TimestampHeaderCellProps) {
+    return (
+        <th>
+            <Link
+                underline="none"
+                color="primary"
+                component="button"
+                onClick={onClick}
+                fontWeight="lg"
+                endDecorator={
+                    arrowIconDirection === 'up' ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />
+                }
+            >
+                Timestamp
+            </Link>
+        </th>
+    );
 }
 
 interface TemperaturesTableProps {
@@ -24,19 +55,29 @@ export default function TemperaturesTable({
     page,
     rowsPerPage,
 }: TemperaturesTableProps) {
-    const [, setSearchParams] = useSearchParams();
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const timestampSortOrder = searchParams.get('sort')?.toLowerCase() === 'asc' ? 'asc' : 'desc';
 
     const lastPage = Math.ceil(totalRecords / temperatures.length);
 
+    const handleTimestampHeaderClick = () => {
+        const newSortOrder = timestampSortOrder === 'asc' ? 'desc' : 'asc';
+        searchParams.set('sort', newSortOrder);
+        searchParams.set('page', DEFAULT_PAGE.toString());
+        setSearchParams(searchParams, { replace: true });
+    };
+
     const handleRowsPerPageChange = (_: React.SyntheticEvent | null, newValue: string) => {
-        setSearchParams({ page: DEFAULT_PAGE.toString(), limit: newValue }, { replace: true });
+        searchParams.set('page', DEFAULT_PAGE.toString());
+        searchParams.set('limit', newValue);
+        setSearchParams(searchParams, { replace: true });
     };
 
     const changePage = (newPage: number) => {
-        setSearchParams(
-            { page: newPage.toString(), limit: rowsPerPage.toString() },
-            { replace: true }
-        );
+        searchParams.set('page', newPage.toString());
+        searchParams.set('limit', rowsPerPage.toString());
+        setSearchParams(searchParams, { replace: true });
     };
 
     const handleFirstPageClick = () => {
@@ -57,12 +98,17 @@ export default function TemperaturesTable({
         changePage(lastPage);
     };
 
+    const timestampHeaderCellArrowDirection = timestampSortOrder === 'asc' ? 'up' : 'down';
+
     return (
         <Sheet variant="outlined" sx={{ borderRadius: 'sm' }}>
-            <Table aria-label="Temperatures Table" noWrap>
+            <Table aria-label="Temperatures Table" noWrap hoverRow stickyHeader>
                 <thead>
                     <tr>
-                        <th style={{ width: '300px' }}>Timestamp</th>
+                        <TimestampHeaderCell
+                            onClick={handleTimestampHeaderClick}
+                            arrowIconDirection={timestampHeaderCellArrowDirection}
+                        />
                         <th style={{ width: '180px' }}>Degrees&nbsp;(°C)</th>
                         <th>Device</th>
                         <th>Location</th>

--- a/WebApp/src/features/temperatures/components/index.ts
+++ b/WebApp/src/features/temperatures/components/index.ts
@@ -2,4 +2,6 @@ export { default as DataCell } from './DataCell';
 export { default as ManageTemperaturesPage } from './ManageTemperaturesPage';
 export { default as TemperaturesTable } from './TemperaturesTable';
 export { default as TablePagination } from './TablePagination';
+export { default as TemperatureFilterOptions } from './TemperatureFilterOptions';
+export { default as TemperatureRangeFilter } from './TemperatureRangeFilter';
 export { default as TemperaturesTableRowMenu } from './TemperaturesTableRowMenu';

--- a/WebApp/src/features/temperatures/components/index.ts
+++ b/WebApp/src/features/temperatures/components/index.ts
@@ -1,4 +1,5 @@
 export { default as DataCell } from './DataCell';
+export { default as DeviceSelect } from './DeviceSelect';
 export { default as ManageTemperaturesPage } from './ManageTemperaturesPage';
 export { default as TemperaturesTable } from './TemperaturesTable';
 export { default as TablePagination } from './TablePagination';

--- a/WebApp/src/features/temperatures/util.ts
+++ b/WebApp/src/features/temperatures/util.ts
@@ -4,16 +4,21 @@ export const MAX_PAGE_LIMIT = 100;
 
 export const DEFAULT_ROWS_PER_PAGE_OPTIONS = [10, 25, 50, 100];
 
+export type TimestampSort = 'asc' | 'desc';
+
 /**
  * Gets the page and limit from a provided URLSearchParams object. If these are not present, or
  * cannot be parsed, the default values (page=1, limit=25) are returned.
  */
-export function getPageAndLimitFromUrlSearchParams(urlSearchParams: URLSearchParams) {
+export function getSearchFilterQueries(urlSearchParams: URLSearchParams) {
     const pageQueryValue = urlSearchParams.get('page');
     const limitQueryValue = urlSearchParams.get('limit');
+    const timestampSortQueryValue = urlSearchParams.get('sort');
 
     const page = pageQueryValue ? parseInt(pageQueryValue) : DEFAULT_PAGE;
     const limit = limitQueryValue ? parseInt(limitQueryValue) : DEFAULT_PAGE_LIMIT;
+    const timestampSort: TimestampSort =
+        timestampSortQueryValue?.toLowerCase() === 'asc' ? 'asc' : 'desc';
 
-    return { page, limit };
+    return { page, limit, timestampSort };
 }

--- a/WebApp/src/features/temperatures/util.ts
+++ b/WebApp/src/features/temperatures/util.ts
@@ -1,3 +1,5 @@
+import { useSearchParams } from 'react-router-dom';
+
 export const DEFAULT_PAGE = 1;
 export const DEFAULT_PAGE_LIMIT = 25;
 export const MAX_PAGE_LIMIT = 100;
@@ -5,20 +7,51 @@ export const MAX_PAGE_LIMIT = 100;
 export const DEFAULT_ROWS_PER_PAGE_OPTIONS = [10, 25, 50, 100];
 
 export type TimestampSort = 'asc' | 'desc';
+export type TemperatureRangeValues = [number, number];
+
+export const GetTemperaturesSearchKeys = {
+    PAGE: 'page',
+    LIMIT: 'limit',
+    TIMESTAMP_SORT: 'sort',
+    MIN_TEMPERATURE: 'minValue',
+    MAX_TEMPERATURE: 'maxValue',
+} as const;
+
+export type SearchFilterQueries = {
+    page: number;
+    limit: number;
+    timestampSort: TimestampSort;
+    minTemperature: number | null;
+    maxTemperature: number | null;
+};
 
 /**
- * Gets the page and limit from a provided URLSearchParams object. If these are not present, or
- * cannot be parsed, the default values (page=1, limit=25) are returned.
+ * Gets the search queries from the URLSearchParams object that can be used to filter the
+ * temperatures results. If these keys are not found, then either the default values are used
+ * or null.
  */
-export function getSearchFilterQueries(urlSearchParams: URLSearchParams) {
-    const pageQueryValue = urlSearchParams.get('page');
-    const limitQueryValue = urlSearchParams.get('limit');
-    const timestampSortQueryValue = urlSearchParams.get('sort');
+export function getSearchFilterQueries(urlSearchParams: URLSearchParams): SearchFilterQueries {
+    const pageQueryValue = urlSearchParams.get(GetTemperaturesSearchKeys.PAGE);
+    const limitQueryValue = urlSearchParams.get(GetTemperaturesSearchKeys.LIMIT);
+    const timestampSortQueryValue = urlSearchParams.get(GetTemperaturesSearchKeys.TIMESTAMP_SORT);
+    const minTemperatureQueryValue = urlSearchParams.get(GetTemperaturesSearchKeys.MIN_TEMPERATURE);
+    const maxTemperatureQueryValue = urlSearchParams.get(GetTemperaturesSearchKeys.MAX_TEMPERATURE);
 
     const page = pageQueryValue ? parseInt(pageQueryValue) : DEFAULT_PAGE;
     const limit = limitQueryValue ? parseInt(limitQueryValue) : DEFAULT_PAGE_LIMIT;
     const timestampSort: TimestampSort =
         timestampSortQueryValue?.toLowerCase() === 'asc' ? 'asc' : 'desc';
+    const minTemperature = minTemperatureQueryValue ? parseFloat(minTemperatureQueryValue) : null;
+    const maxTemperature = maxTemperatureQueryValue ? parseFloat(maxTemperatureQueryValue) : null;
 
-    return { page, limit, timestampSort };
+    return { page, limit, timestampSort, minTemperature, maxTemperature };
+}
+
+/**
+ * Hook that wraps {@link getSearchFilterQueries} to returns the search queries from the current
+ * URLSearchParams.
+ */
+export function useGetSearchFilterQueries() {
+    const [searchParams] = useSearchParams();
+    return getSearchFilterQueries(searchParams);
 }

--- a/WebApp/src/features/temperatures/util.ts
+++ b/WebApp/src/features/temperatures/util.ts
@@ -15,6 +15,7 @@ export const GetTemperaturesSearchKeys = {
     TIMESTAMP_SORT: 'sort',
     MIN_TEMPERATURE: 'minValue',
     MAX_TEMPERATURE: 'maxValue',
+    DEVICE_ID: 'deviceId',
 } as const;
 
 export type SearchFilterQueries = {
@@ -23,6 +24,7 @@ export type SearchFilterQueries = {
     timestampSort: TimestampSort;
     minTemperature: number | null;
     maxTemperature: number | null;
+    deviceIds: string[];
 };
 
 /**
@@ -36,6 +38,7 @@ export function getSearchFilterQueries(urlSearchParams: URLSearchParams): Search
     const timestampSortQueryValue = urlSearchParams.get(GetTemperaturesSearchKeys.TIMESTAMP_SORT);
     const minTemperatureQueryValue = urlSearchParams.get(GetTemperaturesSearchKeys.MIN_TEMPERATURE);
     const maxTemperatureQueryValue = urlSearchParams.get(GetTemperaturesSearchKeys.MAX_TEMPERATURE);
+    const deviceIdQueryValues = urlSearchParams.getAll(GetTemperaturesSearchKeys.DEVICE_ID);
 
     const page = pageQueryValue ? parseInt(pageQueryValue) : DEFAULT_PAGE;
     const limit = limitQueryValue ? parseInt(limitQueryValue) : DEFAULT_PAGE_LIMIT;
@@ -44,7 +47,14 @@ export function getSearchFilterQueries(urlSearchParams: URLSearchParams): Search
     const minTemperature = minTemperatureQueryValue ? parseFloat(minTemperatureQueryValue) : null;
     const maxTemperature = maxTemperatureQueryValue ? parseFloat(maxTemperatureQueryValue) : null;
 
-    return { page, limit, timestampSort, minTemperature, maxTemperature };
+    return {
+        page,
+        limit,
+        timestampSort,
+        minTemperature,
+        maxTemperature,
+        deviceIds: deviceIdQueryValues,
+    };
 }
 
 /**

--- a/WebApp/src/routes/router.tsx
+++ b/WebApp/src/routes/router.tsx
@@ -12,8 +12,11 @@ import {
 import { reactQueryClient } from 'providers/ReactQueryClientProvider';
 import { Navigate, createBrowserRouter } from 'react-router-dom';
 import { PathNames } from './util';
-import { ManageTemperaturesPage, getTemperaturesWithDeviceLoader } from 'features/temperatures';
-import { deleteTemperatureAction } from 'features/temperatures/api/deleteTemperature';
+import {
+    deleteTemperatureAction,
+    ManageTemperaturesPage,
+    getManageTemperaturesPageDataLoader,
+} from 'features/temperatures';
 
 export const browserRouter = createBrowserRouter([
     {
@@ -54,7 +57,7 @@ export const browserRouter = createBrowserRouter([
                     {
                         index: true,
                         element: <ManageTemperaturesPage />,
-                        loader: getTemperaturesWithDeviceLoader(reactQueryClient),
+                        loader: getManageTemperaturesPageDataLoader(reactQueryClient),
                     },
                     {
                         path: `${PathNames.TEMPERATURE_DETAILS}/${PathNames.TEMPERATURE_DELETE}`,


### PR DESCRIPTION
This PR resolves #8 implementing filtering and sorting for temperature results according to the issue's requirements.

As per the demo screenshot below: 
- Filter options for temperature range and device have been added.
- Sorting temperatures by timestamp ascending is now supported. Click on the table header cell (highlighted in blue).

Location based search was decided to not be implemented (see update comments in #8).

<img width="1906" alt="image" src="https://github.com/dphogit/odin/assets/76410203/d7210544-a681-421b-af48-575472f4fe1c">
